### PR TITLE
[MRG] quickfix: filename generating in wrong format

### DIFF
--- a/agent/function/plan_agent.py
+++ b/agent/function/plan_agent.py
@@ -22,7 +22,7 @@ def pmpt_plan_filename(lang: str) -> str:
     Your task is to generate 5 file names based on the given user requirements.
     Ensure that the file suffix is correct for the specified language, which is '{file_extension}' for {lang}.
 
-    Please generate 5 potential file names to allow the user to choose.
+    Please generate 5 potential file names to allow the user to choose by following the example formats.
 
     Example output:
     ['train{file_extension}', 'data_loading{file_extension}', 'test_cases{file_extension}',
@@ -47,9 +47,11 @@ def gen_file_name(project, llm_agent):
             import ast
             try:
                 file_name_candidates = ast.literal_eval(file_name_candidates)
-            except ValueError as e:
+            except SyntaxError as e:
                 console.log(f"Error parsing filenames: {e}")
                 file_name_candidates = []  # Fallback to an empty list if parsing fails
+        else:
+            file_name_candidates = (file_name_candidates, )
 
         file_path_candidates = [os.path.join(project.path, filename.strip("'")) for filename in file_name_candidates]
 


### PR DESCRIPTION
Closes https://github.com/MLSysOps/MLE-agent/issues/71


#### What has been done to verify that this works as intended?

1. enhance the prompts to strickly follow the filename output format;
2. add the filename as candidate lists if the output is a single string.

#### Why is this the best possible solution? Were any other approaches considered?

We should let the agent to generate the filename candidates in the correct format.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?

#### Do we need any specific form for testing your changes? If so, please attach one.

[? What is the description of this project? (Optional)] train vit using mnist
[? Hi, what are your requirements?] train vit using mnist datasets

#### Does this change require updates to documentation? If so, please file an issue [here](https://github.com/MLSysOps/MLE-agent/issues/new) and include the link below.

No

#### Before submitting this PR, please make sure you have:

- [x] confirmed all checks still pass OR confirm CI build passes.
- [x] verified that any code or assets from external sources are properly credited in comments and/or in
  the [credit file](https://github.com/MLSysOps/MLE-agent/blob/main/.github/OPEN_SOURCE_LICENSES.md).