### PR TITLE
[MRG] feat: display planning as the DAG cards

### DIFF
--- a/agent/function/tech_leader.py
+++ b/agent/function/tech_leader.py
@@ -150,7 +150,7 @@ class LeaderAgent:
                             self.requirement,
                             self.model,
                         )
-                        self.console.log(task_dicts)
+                        print(generate_plan_card_ascii_art(task_dicts)) # FIXME: use console
                         self.project.plan.tasks = []
                         for task_dict in task_dicts.get('tasks'):
                             task = match_plan(task_dict)

--- a/agent/function/tech_leader.py
+++ b/agent/function/tech_leader.py
@@ -150,7 +150,7 @@ class LeaderAgent:
                             self.requirement,
                             self.model,
                         )
-                        print(generate_plan_card_ascii_art(task_dicts)) # FIXME: use console
+                        self.console.print(generate_plan_card_ascii(task_dicts), highlight=False)
                         self.project.plan.tasks = []
                         for task_dict in task_dicts.get('tasks'):
                             task = match_plan(task_dict)

--- a/agent/utils/__init__.py
+++ b/agent/utils/__init__.py
@@ -1,3 +1,4 @@
+from .display import *
 from .config import *
 from .prompt import *
 from .system import *

--- a/agent/utils/display.py
+++ b/agent/utils/display.py
@@ -1,0 +1,132 @@
+import os
+from prettytable import PrettyTable
+from colorama import Fore, Style, init
+
+init(autoreset=True)
+
+
+def get_terminal_size():
+    """
+    Get the width of the terminal
+
+    Returns:
+    int: The width of the terminal
+    """
+    try:
+        columns = os.get_terminal_size().columns
+    except OSError:
+        columns = 120  # default width if terminal size cannot be determined
+    return columns
+
+
+def split_text(text, max_width=80, max_lines=3):
+    """
+    Split text based on maximum width and maximum lines
+
+    Args:
+    text (str): The text to be split
+    max_width (int, optional): Maximum width per line. Defaults to 80.
+    max_lines (int, optional): Maximum number of lines. Defaults to 3.
+
+    Returns:
+    list: List of split text
+    """
+    words = text.split()
+    lines = []
+    current_line = words[0]
+
+    for word in words[1:]:
+        if len(current_line) + len(word) < max_width:
+            current_line += " " + word
+        else:
+            if len(lines) >= max_lines - 1:
+                current_line += "..."
+                break
+            lines.append(current_line)
+            current_line = word
+    lines.append(current_line)
+    return lines
+
+
+def generate_one_plan_card_ascii_art(
+    step: int,
+    name: str,
+    resources: list[str],
+    description: str,
+    max_width: int = 80,
+    require_arrow: bool = True,
+):
+    """
+    Generate ASCII art for a single plan card
+
+    Args:
+        step_number (int): The step number
+        name (str): The name of the task
+        resources (list): List of resources
+        description (str): Description of the task
+        max_width (int, optional): Maximum width. Defaults to 80.
+        require_arrow (bool, optional): Whether an arrow is required. Defaults to True.
+
+    Returns:
+        str: ASCII art string
+    """
+    table = PrettyTable()
+    table.title = (
+        Fore.YELLOW
+        + Style.BRIGHT
+        + f"Task {step + 1}: {name}"
+        + Style.RESET_ALL
+    )
+    table.field_names = [
+        Fore.BLUE + "Resources" + Style.RESET_ALL,
+        Fore.GREEN + ", ".join(resources) + Style.RESET_ALL,
+    ]
+    table.add_rows(
+        [
+            [
+                (Fore.BLUE + "Description" + Style.RESET_ALL) if i == 0 else "",
+                Fore.GREEN + s + Style.RESET_ALL,
+            ]
+            for i, s in enumerate(split_text(description, max_width))
+        ]
+    )
+    table.hrules = False
+    table_string = table.get_string()
+
+    terminal_width = get_terminal_size()
+    table_width = len(table_string.split("\n")[0])
+    table_padding = (
+        (terminal_width - table_width) // 2 if terminal_width > table_width else 0
+    )
+
+    strs = ""
+    for line in table_string.split("\n"):
+        strs += " " * table_padding + line + "\n"
+
+    if require_arrow:
+        strs += (
+            " " * (terminal_width // 2) + Fore.MAGENTA + "|" + Style.RESET_ALL + "\n"
+        )
+        strs += (
+            " " * (terminal_width // 2) + Fore.MAGENTA + "V" + Style.RESET_ALL + "\n"
+        )
+
+    return strs
+
+
+def generate_plan_card_ascii_art(task_dicts):
+    """
+    Generate ASCII art for plan cards
+
+    Args:
+        task_dicts (dict): Dictionary of tasks
+
+    Returns:
+        str: ASCII art string
+    """
+    strs = ""
+    for i, plan in enumerate(task_dicts["tasks"]):
+        strs += generate_one_plan_card_ascii_art(
+            step=i, require_arrow=i != len(task_dicts["tasks"]) - 1, **plan
+        )
+    return strs

--- a/agent/utils/display.py
+++ b/agent/utils/display.py
@@ -19,14 +19,14 @@ def get_terminal_size():
     return columns
 
 
-def split_text(text, max_width=80, max_lines=3):
+def split_text(text, max_width=80, max_lines=5):
     """
     Split text based on maximum width and maximum lines
 
     Args:
     text (str): The text to be split
     max_width (int, optional): Maximum width per line. Defaults to 80.
-    max_lines (int, optional): Maximum number of lines. Defaults to 3.
+    max_lines (int, optional): Maximum number of lines. Defaults to 5.
 
     Returns:
     list: List of split text
@@ -48,7 +48,7 @@ def split_text(text, max_width=80, max_lines=3):
     return lines
 
 
-def generate_one_plan_card_ascii_art(
+def generate_one_plan_card_ascii(
     step: int,
     name: str,
     resources: list[str],
@@ -70,6 +70,7 @@ def generate_one_plan_card_ascii_art(
     Returns:
         str: ASCII art string
     """
+    max_width = min(get_terminal_size() // 2 - 10, max_width)
     table = PrettyTable()
     table.title = (
         Fore.YELLOW
@@ -114,7 +115,7 @@ def generate_one_plan_card_ascii_art(
     return strs
 
 
-def generate_plan_card_ascii_art(task_dicts):
+def generate_plan_card_ascii(task_dicts):
     """
     Generate ASCII art for plan cards
 
@@ -126,7 +127,7 @@ def generate_plan_card_ascii_art(task_dicts):
     """
     strs = ""
     for i, plan in enumerate(task_dicts["tasks"]):
-        strs += generate_one_plan_card_ascii_art(
+        strs += generate_one_plan_card_ascii(
             step=i, require_arrow=i != len(task_dicts["tasks"]) - 1, **plan
         )
     return strs

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,6 +6,8 @@ pyyaml
 uvicorn
 fastapi
 requests
+colorama
+prettytable
 questionary
 prompt_toolkit
 pandas~=2.2.2


### PR DESCRIPTION
Closes https://github.com/MLSysOps/MLE-agent/issues/70

#### What has been done to verify that this works as intended?

![screenshot-20240604-224857](https://github.com/MLSysOps/MLE-agent/assets/43229014/5774adf9-a95e-47ce-bbff-9fd8718c527f)

#### Why is this the best possible solution? Were any other approaches considered?

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?

Displaying the task plannings as DAG cards may make it clearer for users to see the agent’s future processes.

#### Do we need any specific form for testing your changes? If so, please attach one.

No

#### Does this change require updates to documentation? If so, please file an issue [here](https://github.com/MLSysOps/MLE-agent/issues/new) and include the link below.

No

#### Before submitting this PR, please make sure you have:

- [ ] confirmed all checks still pass OR confirm CI build passes.
- [ ] verified that any code or assets from external sources are properly credited in comments and/or in
  the [credit file](https://github.com/MLSysOps/MLE-agent/blob/main/.github/OPEN_SOURCE_LICENSES.md).