### PR TITLE
[MRG] fix UI icons

### DIFF
--- a/web/app/page.tsx
+++ b/web/app/page.tsx
@@ -1,7 +1,7 @@
 "use client";
 import React, { useState, useEffect } from 'react';
 import { Layout, Card, Input, Button, message, Form, Select, Spin, Flex, Row, Col } from 'antd';
-import { HomeOutlined, BookOutlined, MailOutlined, GithubOutlined, XOutlined } from '@ant-design/icons';
+import { HomeOutlined, BookOutlined, MailOutlined, GithubOutlined, XOutlined, DiscordOutlined} from '@ant-design/icons';
 import dynamic from "next/dynamic";
 
 const MDEditor = dynamic(
@@ -144,11 +144,11 @@ export default function Home() {
               <Button type="text" block style={{ width: '100px' }} icon={<BookOutlined />} href="https://docs.repx.app/">
                 Docs
               </Button>
-              <Button type="text" block style={{ width: '120px' }} icon={<MailOutlined />} href="https://discord.gg/xHW3Yz4x">
+              <Button type="text" block style={{ width: '120px' }} icon={<DiscordOutlined />} href="https://discord.gg/xHW3Yz4x">
                 Feedback
               </Button>
               <Button type="text" block style={{ minWidth: '48px', maxWidth: '48px' }} icon={<GithubOutlined />} href="https://github.com/MLSysOps/MLE-agent"/>
-              <Button type="text" block style={{ minWidth: '48px', maxWidth: '48px' }} icon={<XOutlined />} href="https://x.com/MLE_Agent/"/>
+              <Button type="text" block style={{ minWidth: '48px', maxWidth: '48px' }} icon={<XOutlined />} href="https://x.com/zhzHNN/"/>
             </Flex>
           </Col>
         </Row>


### PR DESCRIPTION
### **User description**
RT


___

### **PR Type**
enhancement


___

### **Description**
- Added the `DiscordOutlined` icon to the import list to enhance the UI with a new icon for the Feedback button.
- Replaced the `MailOutlined` icon with `DiscordOutlined` for the Feedback button to better represent the Discord link.
- Updated the URL associated with the `XOutlined` icon to point to a new Twitter handle.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>page.tsx</strong><dd><code>Update UI icons and URLs in the navigation bar</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

web/app/page.tsx

<li>Added <code>DiscordOutlined</code> icon to the import statement.<br> <li> Replaced <code>MailOutlined</code> icon with <code>DiscordOutlined</code> for the Feedback <br>button.<br> <li> Updated the URL for the <code>XOutlined</code> button.<br>


</details>


  </td>
  <td><a href="https://github.com/MLSysOps/MLE-agent/pull/201/files#diff-4147e4214fb354e0420dcb3efbfec9df60fae2d3a2e1bdcfa43fb380ff475649">+3/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

