### PR TITLE
[MRG] Update the advisor to support various modes

### DIFF
--- a/mle/agents/summarizer.py
+++ b/mle/agents/summarizer.py
@@ -137,8 +137,8 @@ class SummaryAgent:
     def kaggle_request_summarize(
             self,
             kaggle_overview: str,
-            exp_submission: str = None,
-            submission_file: str = "./submission.csv"):
+            exp_submission: str = None
+    ):
         """
         Summarize the kaggle requests.
         :params: kaggle_overview: the overview json of kaggle competition
@@ -159,8 +159,7 @@ class SummaryAgent:
 
         if exp_submission:
             kaggle_overview += f"""
-            \n\n EXAMPLE SUBMISSION FILE: {exp_submission}\n
-            SUBMISSION FILE LOCATION: {submission_file}
+            \n\n EXAMPLE SUBMISSION FILE: {exp_submission}
             """
 
         chat_history = [


### PR DESCRIPTION
`precise` mode is more suitable for a task with clear metrics and datasets.

Here is an example of using `auto_kaggle` to complete a Kaggle competition:

```sh
mle kaggle --auto \
--datasets "/Users/huangyz0918/Library/Caches/mle-bench/data/spooky-author-identification/prepared/public/train.csv,/Users/huangyz0918/Library/Caches/mle-bench/data/spooky-author-identification/prepared/public/test.csv" \
--description "/Users/huangyz0918/Library/Caches/mle-bench/data/spooky-author-identification/prepared/public/description.md" \
--submission "/Users/huangyz0918/desktop/test-kaggle3/submission.csv" \
--sub_example "/Users/huangyz0918/Library/Caches/mle-bench/data/spooky-author-identification/prepared/public/sample_submission.csv" \
--comp_id "spooky-author-identification"
```

FYI @leeeizhang 