### PR TITLE
[MRG] feat(model): Update gemini.py to use new Gemini API

### DIFF
--- a/mle/agents/advisor.py
+++ b/mle/agents/advisor.py
@@ -124,7 +124,6 @@ class AdviseAgent:
             """
 
         self.functions = [
-            schema_web_search,
             schema_search_arxiv,
             schema_search_papers_with_code,
             schema_preview_csv_data,

--- a/mle/agents/debugger.py
+++ b/mle/agents/debugger.py
@@ -29,7 +29,7 @@ class DebugAgent:
 
     def __init__(self, model, console=None, analyze_only=False):
         """
-        DebugAgent: the agent to run the generated the code and then debug it. The return of the
+        DebugAgent: the agent to run the generated code and then debug it. The return of the
         agent is an instruction to the user to modify the code based on the logs and web search.
 
         Args:

--- a/mle/model/gemini.py
+++ b/mle/model/gemini.py
@@ -114,12 +114,12 @@ class GeminiModel(Model):
         )
 
         final_response_content = None
-        is_final_turn = False 
+        json_output_required = False 
 
         for turn in range(MAX_TOOL_TURNS):
             print(f">>> SENDING REQUEST TO GEMINI (Turn {turn + 1})")
-            current_config = json_only_config if is_final_turn else base_config
-            is_final_turn = False
+            current_config = json_only_config if json_output_required else base_config
+            json_output_required = False
 
             response = self.client.models.generate_content(
                 model=self.model,
@@ -155,8 +155,7 @@ class GeminiModel(Model):
                 )
                 prompt.append(types.Content(role='tool', parts=[function_response_part]))
                 
-                is_final_turn = True
-                continue
+                json_output_required = True
             else:
                 final_response_content = response.text
                 break

--- a/mle/model/gemini.py
+++ b/mle/model/gemini.py
@@ -173,11 +173,11 @@ class GeminiModel(Model):
         Args:
             chat_history: The context (chat history).
         """
-        adapted_history = self._adapt_history_for_gemini(chat_history)
+        prompt = self._adapt_history_for_gemini(chat_history)
 
         response_stream = self.client.models.generate_content_stream(
             model=self.model,
-            contents=adapted_history,
+            contents=prompt,
             config=types.GenerateContentConfig(
                 response_mime_type="application/json",
                 max_output_tokens=4096,

--- a/mle/model/gemini.py
+++ b/mle/model/gemini.py
@@ -113,7 +113,7 @@ class GeminiModel(Model):
         )
 
         final_response_content = None
-        json_output_required = False 
+        json_output_required = False
 
         for _ in range(MAX_TOOL_TURNS):
             config = json_only_config if json_output_required else base_config
@@ -126,7 +126,7 @@ class GeminiModel(Model):
             )
 
             # The model can return multiple function calls. For now, we only process the first one,
-            # as agents' current logic is sequential. 
+            # as agents' current logic is sequential.
             # This is a potential future improvement to handle more complex tasks.
             function_call = None
             if response.candidates and response.candidates[0].content.parts:
@@ -153,7 +153,7 @@ class GeminiModel(Model):
                     response={"result": str(function_result)}
                 )
                 prompt.append(response.candidates[0].content)
-                prompt.append(types.Content(role='tool', parts=[function_response_part]))                
+                prompt.append(types.Content(role='tool', parts=[function_response_part]))
                 json_output_required = True
             else:
                 final_response_content = response.text

--- a/mle/model/gemini.py
+++ b/mle/model/gemini.py
@@ -115,8 +115,7 @@ class GeminiModel(Model):
         final_response_content = None
         json_output_required = False 
 
-        for turn in range(MAX_TOOL_TURNS):
-            print(f">>> SENDING REQUEST TO GEMINI (Turn {turn + 1})")
+        for _ in range(MAX_TOOL_TURNS):
             config = json_only_config if json_output_required else base_config
             json_output_required = False
 

--- a/mle/model/gemini.py
+++ b/mle/model/gemini.py
@@ -117,6 +117,7 @@ class GeminiModel(Model):
         is_final_turn = False 
 
         for turn in range(MAX_TOOL_TURNS):
+            print(f">>> SENDING REQUEST TO GEMINI (Turn {turn + 1}/{MAX_TOOL_TURNS})")
             current_config = json_only_config if is_final_turn else base_config
             is_final_turn = False
 

--- a/mle/model/gemini.py
+++ b/mle/model/gemini.py
@@ -132,7 +132,7 @@ class GeminiModel(Model):
                     if part.function_call:
                         function_call = part.function_call
                         break
-            
+
             if function_call:                
                 prompt.append(response.candidates[0].content)
                 function_name = process_function_name(function_call.name)

--- a/mle/model/gemini.py
+++ b/mle/model/gemini.py
@@ -118,13 +118,13 @@ class GeminiModel(Model):
 
         for turn in range(MAX_TOOL_TURNS):
             print(f">>> SENDING REQUEST TO GEMINI (Turn {turn + 1})")
-            current_config = json_only_config if json_output_required else base_config
+            config = json_only_config if json_output_required else base_config
             json_output_required = False
 
             response = self.client.models.generate_content(
                 model=self.model,
                 contents=prompt,
-                config=current_config,
+                config=config,
             )
 
             function_call = None
@@ -134,7 +134,7 @@ class GeminiModel(Model):
                         function_call = part.function_call
                         break
 
-            if function_call:                
+            if function_call:
                 prompt.append(response.candidates[0].content)
                 function_name = process_function_name(function_call.name)
                 arguments = dict(function_call.args)
@@ -153,8 +153,7 @@ class GeminiModel(Model):
                     name=function_name,
                     response={"result": str(function_result)}
                 )
-                prompt.append(types.Content(role='tool', parts=[function_response_part]))
-                
+                prompt.append(types.Content(role='tool', parts=[function_response_part]))                
                 json_output_required = True
             else:
                 final_response_content = response.text

--- a/mle/model/gemini.py
+++ b/mle/model/gemini.py
@@ -117,7 +117,7 @@ class GeminiModel(Model):
         is_final_turn = False 
 
         for turn in range(MAX_TOOL_TURNS):
-            print(f">>> SENDING REQUEST TO GEMINI (Turn {turn + 1}/{MAX_TOOL_TURNS})")
+            print(f">>> SENDING REQUEST TO GEMINI (Turn {turn + 1})")
             current_config = json_only_config if is_final_turn else base_config
             is_final_turn = False
 
@@ -165,12 +165,7 @@ class GeminiModel(Model):
             final_response_content = f"[GEMINI WARNING]: Max tool turns of {MAX_TOOL_TURNS} reached."
             print(final_response_content)
 
-        try:
-            json.loads(final_response_content)
-            return final_response_content
-        except (json.JSONDecodeError, TypeError) as e:
-            print(f"[GEMINI ERROR]: Failed to parse final response as JSON. Error: {e}")
-            return final_response_content
+        return final_response_content
 
     def stream(self, chat_history, **kwargs):
         """


### PR DESCRIPTION
Closes #302

`advisor.py`
remove the duplicate [schema_web_search](https://github.com/MLSysOps/MLE-agent/blob/cf9762d3abd3cad227bbd859a3ef4f95dff164a3/mle/agents/advisor.py#L134)

`gemini.py` uses the `google-genai` SDK, highlights:
1. [gemini api migrate doc](https://ai.google.dev/gemini-api/docs/migrate#automatic-function) states the new SDK promotes a stateless approach as its primary interaction model, which is a significant change from the stateful sessions that were central to the old SDK. Specially, instead of [`model.start_chat`](https://github.com/MLSysOps/MLE-agent/blob/cf9762d3abd3cad227bbd859a3ef4f95dff164a3/mle/model/gemini.py#L111), now it's `client.models.generate_content()`
2. As pointed out in the [issue](https://github.com/MLSysOps/MLE-agent/issues/302#issuecomment-3055393252), the new Gemini API [function calling](https://ai.google.dev/gemini-api/docs/function-calling?example=meeting#step-2) requires an explicit process to first get a tool call suggestion and then a separate API call to get the final structured output (`AdviseAgent` etc all requires structured JSON to work). 
3. Instead of using recursive (as [openai.py does](https://github.com/syangx38/MLE-agent/blob/9d7f80b4b921fc3232713a7b8731ecb61c6d5b52/mle/model/openai.py#L69)), used iterative loop to manage the multi-turn conversation for tool calling.
4. def query() method logic:
```
def query(chat_history, **kwargs):
    // Initial Setup
    system_instruction, prompt
    tools
    json_output_required = False // Flag to force JSON output

    // Tool-Calling Loop
    FOR LOOP:
        config = json_only_config IF json_output_required ELSE base_config
        json_output_required = False

        response = call_gemini_api(prompt, config)
        function_call = get_function_call_from(response)

        IF function_call:
            execute the local function            
            append model's response part to prompt
            append tool_result
            json_output_required = True // Set the flag 
        ELSE:
            // The model returned text
            final_response_content = get_text_from(response)
            BREAK 

    // Return the raw string content for the calling agent to handle
    RETURN final_response_content
```

---------------------------------------------------------------------------------------------
#### What has been done to verify that this works as intended?
sample logs below
```
Applying feature engineering...
Starting training with 5-Fold Stratified Cross-Validation...
--- Fold 1/5 ---
--- Fold 2/5 ---
--- Fold 3/5 ---
--- Fold 4/5 ---
--- Fold 5/5 ---
Overall OOF AUC: 0.88561
Submission file created successfully at ./tabular-playground-may-2022/public/submission.csv
First 5 rows of submission file:
       id    target
0  800000  0.609488
1  800001  0.440478
2  800002  0.892964
3  800003  0.574231
4  800004  0.362269
```

#### Why is this the best possible solution? Were any other approaches considered?
Checked as the official doc required https://ai.google.dev/gemini-api/docs/migrate extensively.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?
Will implement gemini users, but users can switch to other models.

#### Do we need any specific form for testing your changes? If so, please attach one.
No. 

#### Does this change require updates to documentation? If so, please file an issue [here](https://github.com/MLSysOps/MLE-agent/issues/new) and include the link below.
No.

#### Before submitting this PR, please make sure you have:
- [x] confirmed all checks still pass OR confirm CI build passes.
- [x] verified that any code or assets from external sources are properly credited in comments and/or in
  the [credit file](https://github.com/MLSysOps/MLE-agent/blob/main/.github/OPEN_SOURCE_LICENSES.md).