### PR TITLE
[MRG] add mem0 memory

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -48,6 +48,7 @@ dependencies = [
   "lancedb==0.15.0 ; python_version >= '3.9'",
   "lancedb==0.6.13 ; python_version < '3.9'",
   "tree-sitter>=0.21.3",
+  "mem0ai~=0.1.114",
 ]
 
 [project.urls]


### PR DESCRIPTION
Closes https://github.com/MLSysOps/MLE-agent/issues/298

Use the `Mem0` to store and retrieve long-term chat history in memory.
- `infer=True` enables automatic memory summarization.
- chat history is structured using role and content, compatible with OpenAI chat format.
- each memory entry is deduplicated via content hash and time-stamped for tracking.

```python
from mle.utils.memory import Mem0

# initialize memory instance
mem = Mem0()

# A chat session example
chat_sessions: list[dict[str, str]] = [
    {"role": "system", "content": "You are a helpful assistant."},
    {"role": "assistant", "content": "What is your favorite city?"},
    {"role": "user", "content": "The capital of France, Paris."},
    {"role": "assistant", "content": "Sure, I will remember for these"},
]

# store the session with automatic summarization
mem.add(chat_sessions, infer=True, prompt="Remember the information for the user")

# retrieve all stored memories
mem.get_all()
```

output example:
```
{
  "results": [
    {
      "id": "066436ec-e495-4f27-988d-223e5db68c9e",
      "memory": "Favorite city is Paris, the capital of France",
      "hash": "11828c80c2d0105db6c02af3adc7aec4",
      "metadata": null,
      "created_at": "2025-07-13T05:01:23.911676-07:00",
      "updated_at": null,
      "agent_id": "default"
    }
  ]
}
```

#### Before submitting this PR, please make sure you have:

- [x] confirmed all checks still pass OR confirm CI build passes.
- [x] verified that any code or assets from external sources are properly credited in comments and/or in
  the [credit file](https://github.com/MLSysOps/MLE-agent/blob/main/.github/OPEN_SOURCE_LICENSES.md).